### PR TITLE
Improved formatting of the printed results (replaced tabs with padding, ...

### DIFF
--- a/BenchmarkIt/BenchmarkIt.csproj
+++ b/BenchmarkIt/BenchmarkIt.csproj
@@ -7,6 +7,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>BenchmarkIt</RootNamespace>
     <AssemblyName>BenchmarkIt</AssemblyName>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,6 +54,7 @@
     <Compile Include="BenchmarkType.cs" />
     <Compile Include="Result.cs" />
     <Compile Include="Constraint.cs" />
+    <Compile Include="ResultColumn.cs" />
     <Compile Include="ResultExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/BenchmarkIt/Result.cs
+++ b/BenchmarkIt/Result.cs
@@ -5,48 +5,64 @@ using System.Text;
 
 namespace BenchmarkIt
 {
-	public class Result
-	{
-	    private string _label;
-	    private readonly BenchmarkType _type;
+    public class Result
+    {
+        private string _label;
+        private readonly BenchmarkType _type;
 
-	    public Result(string label, BenchmarkType type)
+        private static readonly ResultColumn[] _timeResultColumns = new ResultColumn[]
 	    {
-	        _label = label;
-	        _type = type;
-	    }
+	        new ResultColumn(header: "Name", width: 40),
+            new ResultColumn(header: "Iterations", width: 20),
+            new ResultColumn(header: "Percent", width: 30), 
+	    };
 
-	    /// <summary>
+        private static readonly ResultColumn[] _iterationResultColumns = new ResultColumn[]
+	    {
+	        new ResultColumn(header: "Name", width: 40),
+            new ResultColumn(header: "Milliseconds", width: 20),
+            new ResultColumn(header: "Percent", width: 30), 
+	    };
+
+        public Result(string label, BenchmarkType type)
+        {
+            _label = label;
+            _type = type;
+        }
+
+        /// <summary>
         /// Gets the stopwatch used to time the benchmark
         /// </summary>
-	    public Stopwatch Stopwatch { get; internal set;}
+        public Stopwatch Stopwatch { get; internal set; }
 
         /// <summary>
         /// Gets the total iterations that occured during the benchmark
         /// </summary>
-		public int TotalIterations { get; internal set; }
+        public int TotalIterations { get; internal set; }
 
         /// <summary>
         /// Gets a string containing some formated stats about the result
         /// </summary>
-		public string Stats {
-			get {
-				var sb = new StringBuilder ();
+        public string Stats
+        {
+            get
+            {
+                var sb = new StringBuilder();
 
-			    sb.Append("-----");
-			    sb.Append(_label);
-			    sb.AppendLine("-----");
-				sb.AppendLine ("Total time: " + Stopwatch.Elapsed);
-				sb.AppendLine ("Ticks per execute: " + Stopwatch.ElapsedTicks / TotalIterations);
-				sb.AppendLine ("Milliseconds per execute: " + Stopwatch.ElapsedMilliseconds / TotalIterations);
+                sb.Append("-----");
+                sb.Append(_label);
+                sb.AppendLine("-----");
+                sb.AppendLine("Total time: " + Stopwatch.Elapsed);
+                sb.AppendLine("Ticks per execute: " + Stopwatch.ElapsedTicks / TotalIterations);
+                sb.AppendLine("Milliseconds per execute: " + Stopwatch.ElapsedMilliseconds / TotalIterations);
 
-				return sb.ToString ();
-			}
-		}
+                return sb.ToString();
+            }
+        }
 
-	    public void PrintStats()
-	    {
-	        var originalColor = Console.ForegroundColor;
+        public void PrintStats()
+        {
+            var originalColor = Console.ForegroundColor;
 
             Console.Write("----- Stats for ");
 
@@ -55,38 +71,38 @@ namespace BenchmarkIt
             Console.ForegroundColor = originalColor;
             Console.WriteLine("-----");
 
-	        Console.Write("Total time: ");
-	        Console.ForegroundColor = ConsoleColor.Red;
+            Console.Write("Total time: ");
+            Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine(Stopwatch.Elapsed);
-	        Console.ForegroundColor = originalColor;
+            Console.ForegroundColor = originalColor;
 
-	        Console.Write("Ticks per execute: ");
+            Console.Write("Ticks per execute: ");
             Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine(Stopwatch.ElapsedTicks / TotalIterations);
-	        Console.ForegroundColor = originalColor;
+            Console.ForegroundColor = originalColor;
 
-	        Console.Write("Milliseconds per execute: ");
+            Console.Write("Milliseconds per execute: ");
             Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine("Milliseconds per execute: " + Stopwatch.ElapsedMilliseconds / TotalIterations);
             Console.ForegroundColor = originalColor;
-	    }
+        }
 
         /// <summary>
         /// Compares this result against one or more other results and returns a string with information
         /// </summary>
         /// <param name="results">Other results</param>
-	    public void Compare(params Result[] results)
-	    {
-	        var mergedResults = results.ToList();
+        public void Compare(params Result[] results)
+        {
+            var mergedResults = results.ToList();
             mergedResults.Insert(0, this);
-	        PrintComparison(mergedResults.ToArray());
-	    }
-        
+            PrintComparison(mergedResults.ToArray());
+        }
+
         /// <summary>
         /// Compares the given results against one another
         /// </summary>
         /// <param name="results"></param>
-	    public static void PrintComparison(params Result[] results)
+        public static void PrintComparison(params Result[] results)
         {
             if (results[0]._type == BenchmarkType.Iterations)
             {
@@ -96,57 +112,67 @@ namespace BenchmarkIt
             {
                 PrintComparisonTime(results);
             }
-	    }
+        }
 
-	    private static void PrintComparisonTime(Result[] results)
-	    {
-	        var type = results[0]._type;
+        private static void PrintComparisonTime(Result[] results)
+        {
+            var type = results[0]._type;
 
             Result leastIterations = results[0], mostIterations = results[0];
-	        for (int i = 0; i < results.Length; i++)
-	        {
-	            var result = results[i];
-	            if (result._type != type)
-	            {
-	                throw new ArgumentException(
-	                    "Can not compare results that are of a different metric (i.e. one time based, another iteration based)");
-	            }
-                
-	            // we are intrested in iterations
-	            if (leastIterations.TotalIterations > result.TotalIterations)
-	            {
-	                leastIterations = result;
-	            }
-	            else if (mostIterations.TotalIterations < result.TotalIterations)
-	            {
-	                mostIterations = result;
-	            }
-	        }
+            for (int i = 0; i < results.Length; i++)
+            {
+                var result = results[i];
+                if (result._type != type)
+                {
+                    throw new ArgumentException(
+                        "Can not compare results that are of a different metric (i.e. one time based, another iteration based)");
+                }
 
-	        var originalColor = Console.ForegroundColor;
+                // we are intrested in iterations
+                if (leastIterations.TotalIterations > result.TotalIterations)
+                {
+                    leastIterations = result;
+                }
+                else if (mostIterations.TotalIterations < result.TotalIterations)
+                {
+                    mostIterations = result;
+                }
+            }
 
-            Console.WriteLine("Name\tIterations\tPercent");
+            var originalColor = Console.ForegroundColor;
 
-	        for (int i = 0; i < results.Length; i++)
-	        {
-	            var result = results[i];
+            // header
+            var header = string.Join("", _timeResultColumns.Select(c => c.Header.PadRight(c.Width)));
+            Console.WriteLine(header);
 
-	            Console.ForegroundColor = ConsoleColor.Red;
-	            if (result.TotalIterations == mostIterations.TotalIterations)
-	            {
-	                Console.ForegroundColor = ConsoleColor.Green;
-	            }
+            // results columns
+            for (int i = 0; i < results.Length; i++)
+            {
+                var result = results[i];
 
-                var percentLess = ((double)result.TotalIterations / (double)mostIterations.TotalIterations) * 100.0d;
+                Console.ForegroundColor = ConsoleColor.Red;
+                if (result.TotalIterations == mostIterations.TotalIterations)
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                }
 
-                Console.Write(result._label);
-                Console.Write("\t");
-                Console.Write(result.TotalIterations);
-                Console.Write("\t");
-                Console.WriteLine(percentLess + "%");
-	        }
-	        Console.ForegroundColor = originalColor;
-	    }
+                var percentLess = Math.Round((double)result.TotalIterations / (double)mostIterations.TotalIterations * 100.0d, 1);
+
+                var outputColumns = new object[]
+                {
+                    result._label,
+                    result.TotalIterations,
+                    percentLess + "%"
+                };
+
+                for (int c = 0; c < outputColumns.Length; c++)
+                {
+                    Console.Write(outputColumns[c].ToString().PadRight(_timeResultColumns[c].Width));
+                }
+                Console.Write("\r");
+            }
+            Console.ForegroundColor = originalColor;
+        }
 
         private static void PrintComparisonIterations(Result[] results)
         {
@@ -180,30 +206,36 @@ namespace BenchmarkIt
 
             var originalColor = Console.ForegroundColor;
 
-            Console.WriteLine("Name\tTicks\t\tMS\tPercent");
+            // header
+            var header = string.Join("", _iterationResultColumns.Select(c => c.Header.PadRight(c.Width)));
+            Console.WriteLine(header);
 
-            for (int i = 0; i < results.Length; i++)
+            // results columns
+            foreach (var result in results)
             {
-                var result = results[i];
-
                 Console.ForegroundColor = ConsoleColor.Red;
                 if (result.Stopwatch.ElapsedTicks == lowestTime.Stopwatch.ElapsedTicks)
                 {
                     Console.ForegroundColor = ConsoleColor.Green;
                 }
 
-                var percentLess = ((double)result.Stopwatch.ElapsedTicks / (double)lowestTime.Stopwatch.ElapsedTicks) * 100.0d;
+                var percentLess = Math.Round((double)result.Stopwatch.ElapsedTicks / (double)lowestTime.Stopwatch.ElapsedTicks * 100.0d, 1);
 
-                Console.Write(result._label);
-                Console.Write("\t");
-                Console.Write(result.Stopwatch.ElapsedTicks);
-                Console.Write("\t\t");
-                Console.Write(result.Stopwatch.ElapsedMilliseconds);
-                Console.Write("\t");
-                Console.WriteLine(percentLess + "%");
+                var outputColumns = new object[]
+                {
+                    result._label,
+                    result.Stopwatch.ElapsedMilliseconds,
+                    percentLess + "%"
+                };
+
+                for (int c = 0; c < outputColumns.Length; c++)
+                {
+                    Console.Write(outputColumns[c].ToString().PadRight(_iterationResultColumns[c].Width));
+                }
+                Console.Write("\r");
             }
             Console.ForegroundColor = originalColor;
         }
-	}
+    }
 }
 

--- a/BenchmarkIt/ResultColumn.cs
+++ b/BenchmarkIt/ResultColumn.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BenchmarkIt
+{
+    public class ResultColumn
+    {
+        public string Header { get; set; }
+        public int Width { get; set; }
+
+        public ResultColumn(string header, int width)
+        {
+            this.Header = header;
+            this.Width = width;
+        }
+    }
+}


### PR DESCRIPTION
Improved formatting of the printed results (replaced tabs with padding, as tabs are unreliable with different size lengths)

Removed the redundant ticks column from iteration results (already there are milliseconds, more precision is rarely needed)

Changed percentage rounding to 1 digit after the floating point.
