### PR TITLE
Added GC.Collect before benchmarking

### DIFF
--- a/BenchmarkIt/Benchmark.cs
+++ b/BenchmarkIt/Benchmark.cs
@@ -12,7 +12,7 @@ namespace BenchmarkIt
         private readonly List<Tuple<string, Action>> _functions;
 
         private int _amount;
-        private int _warmup;
+        private int _warmup=1;
 
         private readonly Constraint _constraint;
         private readonly Against _against;
@@ -62,9 +62,9 @@ namespace BenchmarkIt
         /// <value>The benchmark</value>
         public Benchmark WithWarmup(int n)
         {
-            if (n < 0)
+            if (n < 1)
             {
-                throw new ArgumentException("The number of warmup iterations can not be negative");
+                throw new ArgumentException("The number of warmup iterations can not be less than one");
             }
             _warmup = n;
             return this;


### PR DESCRIPTION
It's better to give the test as good a chance as possible of avoiding garbage collection during the test.
During a GC collection all threads are paused, far from ideal in a benchmarking method.
